### PR TITLE
feat: Set default user status to PENDING during creation

### DIFF
--- a/build/routes.ts
+++ b/build/routes.ts
@@ -4,7 +4,7 @@
 import type { TsoaRoute } from '@tsoa/runtime';
 import {  fetchMiddlewares, ExpressTemplateService } from '@tsoa/runtime';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-import { UserController } from './../src/user-service/infraestructure/controllers/user.controller';
+import { UserController } from './../src/auth-service/infraestructure/controllers/user.controller';
 import type { Request as ExRequest, Response as ExResponse, RequestHandler, Router } from 'express';
 
 
@@ -20,11 +20,13 @@ const models: TsoaRoute.Models = {
             "email": {"dataType":"string","required":true},
             "current_password": {"dataType":"string","required":true},
             "roleId": {"dataType":"string","required":true},
-            "status": {"dataType":"string","required":true},
+            "status": {"dataType":"union","subSchemas":[{"dataType":"enum","enums":["ACTIVE"]},{"dataType":"enum","enums":["INACTIVE"]},{"dataType":"enum","enums":["PENDING"]}],"required":true},
             "created_at": {"dataType":"datetime","required":true},
             "updated_at": {"dataType":"datetime","required":true},
             "resetPasswordToken": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},
             "expiresTokenPasswordAt": {"dataType":"union","subSchemas":[{"dataType":"datetime"},{"dataType":"enum","enums":[null]}],"required":true},
+            "verificationCode": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},
+            "verificationCodeExpires": {"dataType":"union","subSchemas":[{"dataType":"datetime"},{"dataType":"enum","enums":[null]}],"required":true},
         },
         "additionalProperties": false,
     },
@@ -47,7 +49,7 @@ export function RegisterRoutes(app: Router) {
 
     
         const argsUserController_createUser: Record<string, TsoaRoute.ParameterSchema> = {
-                requestBody: {"in":"body","name":"requestBody","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"roleId":{"dataType":"string"},"status":{"dataType":"string","required":true},"current_password":{"dataType":"string","required":true},"email":{"dataType":"string","required":true},"fullname":{"dataType":"string","required":true}}},
+                requestBody: {"in":"body","name":"requestBody","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"roleId":{"dataType":"string"},"current_password":{"dataType":"string","required":true},"email":{"dataType":"string","required":true},"fullname":{"dataType":"string","required":true}}},
         };
         app.post('/users',
             ...(fetchMiddlewares<RequestHandler>(UserController)),

--- a/build/swagger.json
+++ b/build/swagger.json
@@ -25,7 +25,12 @@
 						"type": "string"
 					},
 					"status": {
-						"type": "string"
+						"type": "string",
+						"enum": [
+							"ACTIVE",
+							"INACTIVE",
+							"PENDING"
+						]
 					},
 					"created_at": {
 						"type": "string",
@@ -43,6 +48,15 @@
 						"type": "string",
 						"format": "date-time",
 						"nullable": true
+					},
+					"verificationCode": {
+						"type": "string",
+						"nullable": true
+					},
+					"verificationCodeExpires": {
+						"type": "string",
+						"format": "date-time",
+						"nullable": true
 					}
 				},
 				"required": [
@@ -54,7 +68,9 @@
 					"created_at",
 					"updated_at",
 					"resetPasswordToken",
-					"expiresTokenPasswordAt"
+					"expiresTokenPasswordAt",
+					"verificationCode",
+					"verificationCodeExpires"
 				],
 				"type": "object",
 				"additionalProperties": false
@@ -97,9 +113,6 @@
 									"roleId": {
 										"type": "string"
 									},
-									"status": {
-										"type": "string"
-									},
 									"current_password": {
 										"type": "string"
 									},
@@ -111,7 +124,6 @@
 									}
 								},
 								"required": [
-									"status",
 									"current_password",
 									"email",
 									"fullname"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,4 +1,3 @@
-
 generator client {
   provider = "prisma-client-js"
 }
@@ -32,13 +31,19 @@ model User {
   current_password        String
   roleId                  String    @db.ObjectId
   role                    Role      @relation(fields: [roleId], references: [id])
-  status                  String
+  status                  Status    @default(PENDING)
   created_at              DateTime
   updated_at              DateTime
-  verificationCode        String
-  verificationCodeExpires DateTime
+  verificationCode        String?
+  verificationCodeExpires DateTime?
   resetPasswordToken      String?
   expiresTokenPasswordAt  DateTime?
 
   @@map("users")
+}
+
+enum Status {
+  ACTIVE
+  INACTIVE
+  PENDING
 }

--- a/src/auth-service/application/user.service.ts
+++ b/src/auth-service/application/user.service.ts
@@ -1,41 +1,39 @@
-import { IUserRepository } from '../domain/interfaces/user.interface';
-import { User } from '../domain/entity/user';
-import { PasswordService } from '../../shared/infraestructure/bcryptHasher';
-import { EmailSenderInterface } from 'src/shared/domain/interfaces/emailSender.interface';
-import { generateVerificationCode } from '../../../lib/verification';
+import { IUserRepository } from "../domain/interfaces/user.interface";
+import { User } from "../domain/entity/user";
+import { PasswordService } from "../../shared/infraestructure/bcryptHasher";
+import { EmailSenderInterface } from "src/shared/domain/interfaces/emailSender.interface";
+import { generateVerificationCode } from "../../../lib/verification";
 
 export class UserService {
   private userRepository: IUserRepository;
   private passwordService: PasswordService;
-  private emailSender: EmailSenderInterface
+  private emailSender: EmailSenderInterface;
 
-  constructor(userRepository: IUserRepository, passwordService: PasswordService, emailSender: EmailSenderInterface) {
+  constructor(
+    userRepository: IUserRepository,
+    passwordService: PasswordService,
+    emailSender: EmailSenderInterface
+  ) {
     this.userRepository = userRepository;
-    this.passwordService = passwordService
-    this.emailSender = emailSender
+    this.passwordService = passwordService;
+    this.emailSender = emailSender;
   }
 
   async createUser(
     fullname: string,
     email: string,
     current_password: string,
-    status: string,
     roleId?: string
   ): Promise<User> {
-    const user = this.userRepository.getByEmail(email);
-    if (!user) {
-      throw new Error('Ya existe un usuario con ese email');
+    const existingUser = await this.userRepository.getByEmail(email);
+    if (existingUser) {
+      throw new Error("Ya existe un usuario con ese email");
     }
-    const passwordHash = await this.passwordService.hashPassword(current_password);
-
-    const newUser = new User(
-      fullname,
-      email,
-      passwordHash,
-      status,
-      roleId
+    const passwordHash = await this.passwordService.hashPassword(
+      current_password
     );
-    
+
+    const newUser = new User(fullname, email, passwordHash, roleId);
 
     const verificationCode = generateVerificationCode();
     await this.emailSender.sendEmail({
@@ -47,4 +45,3 @@ export class UserService {
     return await this.userRepository.createUser(newUser);
   }
 }
-

--- a/src/auth-service/domain/entity/user.ts
+++ b/src/auth-service/domain/entity/user.ts
@@ -1,21 +1,23 @@
+
 export class User {
   id?: string;
   fullname: string;
   email: string;
   current_password: string;
   roleId: string;
-  status: string;
+  status: 'ACTIVE' | 'INACTIVE' | 'PENDING'; 
   created_at: Date;
   updated_at: Date;
   resetPasswordToken: string | null;
   expiresTokenPasswordAt: Date | null;
+  verificationCode: string | null;
+  verificationCodeExpires: Date | null;
 
   constructor(
     fullname: string,
     email: string,
     current_password: string,
-    status: string,
-    roleId: string = 'userRoleId',
+    roleId: string = "userRoleId",
     id?: string
   ) {
     if (email) {
@@ -25,30 +27,31 @@ export class User {
     // Validate null/empty field
     if (!fullname || !email || !current_password) {
       throw new Error(
-        'Los campos fullname, email y current_password son obligatorios.'
+        "Los campos fullname, email y current_password son obligatorios."
       );
     }
 
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     if (!emailRegex.test(email)) {
-      throw new Error('El formato del email es inválido.');
+      throw new Error("El formato del email es inválido.");
     }
 
     if (current_password.length < 6) {
-      throw new Error('La contraseña debe tener al menos 6 caracteres.');
+      throw new Error("La contraseña debe tener al menos 6 caracteres.");
     }
     this.fullname = fullname;
     this.email = email;
     this.current_password = current_password;
     this.roleId = roleId;
-    this.status = status;
+    this.status = "PENDING"; 
     this.created_at = new Date();
     this.updated_at = new Date();
     this.resetPasswordToken = null;
     this.expiresTokenPasswordAt = null;
-    if(id){
+    this.verificationCode = null;
+    this.verificationCodeExpires = null;
+    if (id) {
       this.id = id;
     }
   }
-
 }

--- a/src/auth-service/infraestructure/controllers/user.controller.ts
+++ b/src/auth-service/infraestructure/controllers/user.controller.ts
@@ -32,17 +32,15 @@ export class UserController extends Controller {
       fullname: string;
       email: string;
       current_password: string;
-      status: string;
       roleId?: string;
     }
   ): Promise<User> {
     this.setStatus(201); 
-    const { fullname, email, current_password, status, roleId } = requestBody;
+    const { fullname, email, current_password, roleId } = requestBody;
     return await this.userService.createUser(
       fullname,
       email,
       current_password,
-      status,
       roleId
     );
   }

--- a/src/auth-service/infraestructure/repository/user.repository.ts
+++ b/src/auth-service/infraestructure/repository/user.repository.ts
@@ -18,6 +18,8 @@ export class UserRepository implements IUserRepository {
         updated_at: new Date(),
         resetPasswordToken: null,
         expiresTokenPasswordAt: null,
+        verificationCode: null,
+        verificationCodeExpires: null,
       },
     })
   }


### PR DESCRIPTION
This pull request introduces a change to the User entity to set the default status of newly created users to PENDING.
The motivation for this change is to ensure that all new user accounts are initially created with a PENDING status. This allows for a email verification process to be completed before the user is fully active.